### PR TITLE
도메인 객체 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'mysql:mysql-connector-java'
+	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.rest-assured:rest-assured'

--- a/src/main/java/com/musinsa/assignment/domain/Brand.java
+++ b/src/main/java/com/musinsa/assignment/domain/Brand.java
@@ -1,0 +1,14 @@
+package com.musinsa.assignment.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class Brand {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+    private String name;
+}

--- a/src/main/java/com/musinsa/assignment/domain/Category.java
+++ b/src/main/java/com/musinsa/assignment/domain/Category.java
@@ -1,0 +1,15 @@
+package com.musinsa.assignment.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class Category {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+    private String name;
+
+}

--- a/src/main/java/com/musinsa/assignment/domain/Product.java
+++ b/src/main/java/com/musinsa/assignment/domain/Product.java
@@ -1,0 +1,26 @@
+package com.musinsa.assignment.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class Product {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @JoinColumn
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Category category;
+
+    @JoinColumn
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Brand brand;
+
+    private int price;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,7 @@ spring:
         show_sql: false
         default_batch_fetch_size: 100
     defer-datasource-initialization: true
+    open-in-view: false
 
 logging.level:
   org:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,13 @@
 spring:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/musinsa
-    username: louie
-    password: '0524'
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:musinsa
+    username: sa
+
+  sql:
+    init:
+      mode: always
+      encoding: utf-8
   jpa:
     hibernate:
       ddl-auto: create
@@ -11,15 +15,9 @@ spring:
       hibernate:
         format_sql: true
         show_sql: false
-#        dialect: Mysql
         default_batch_fetch_size: 100
     defer-datasource-initialization: true
 
-  sql:
-    init:
-      mode: always
-      encoding: UTF-8
-
-logging:
-  level:
-    org.hibernate.SQL: debug
+logging.level:
+  org:
+    hibernate.SQL: debug


### PR DESCRIPTION
## Description
- 도메인 객체 구현
  - 불필요한 양방향 매핑을 구현하지 않기 위해서 일단 모든 엔티티를 단방향 매핑으로 구현하고 기능 개발 도중 양방향 매핑이 필요할 때만 구현할 예정입니다.
- chore : Mysql에서 H2로 DBMS 변경

  - 해당 프로젝트를 clone 받고 바로 실행할 수 있도록 H2의 메모리 DB를 사용했습니다.